### PR TITLE
ildaeil: fix ImGui assertion error in debug builds

### DIFF
--- a/plugins/Cardinal/src/Ildaeil.cpp
+++ b/plugins/Cardinal/src/Ildaeil.cpp
@@ -1445,7 +1445,7 @@ struct IldaeilWidget : ImGuiWidget, IdleCallback, Thread {
                 ImGui::SetKeyboardFocusHere();
             }
 
-            if (ImGui::InputText("", fPluginSearchString, sizeof(fPluginSearchString)-1,
+            if (ImGui::InputText("##pluginsearch", fPluginSearchString, sizeof(fPluginSearchString)-1,
                                  ImGuiInputTextFlags_CharsNoBlank|ImGuiInputTextFlags_AutoSelectAll))
                 fPluginSearchActive = true;
 
@@ -1463,7 +1463,7 @@ struct IldaeilWidget : ImGuiWidget, IdleCallback, Thread {
                 break;
             }
 
-            if (ImGui::Combo("", &current, pluginTypes, ARRAY_SIZE(pluginTypes)))
+            if (ImGui::Combo("##plugintypes", &current, pluginTypes, ARRAY_SIZE(pluginTypes)))
             {
                 fIdleState = kIdleChangePluginType;
                 switch (current)


### PR DESCRIPTION
Empty widgets labels generate IDs that conflict with the main window. 

This fixes the assertion error with ImGui in debug builds:
```
Cardinal/src/DearImGui/imgui_widgets.cpp:632: bool ImGui::ButtonBehavior(const ImRect&, ImGuiID, bool*, bool*, ImGuiButtonFlags): Assertion mouse_button >= 0 && mouse_button < ImGuiMouseButton_COUNT' failed.
```
See https://github.com/ocornut/imgui/issues/4796 which is precisely the same issue.
More info: https://github.com/ocornut/imgui/blob/master/docs/FAQ.md#q-how-can-i-have-widgets-with-an-empty-label
