### PR TITLE
[WIP] Ildaeil: 8 CV input expander for plugin parameter

### DIFF
--- a/plugins/Cardinal/plugin.json
+++ b/plugins/Cardinal/plugin.json
@@ -75,6 +75,15 @@
       "tags": [
         "Utility"
       ]
+    },
+    {
+      "slug": "IldaeilExpIn8",
+      "disabled": false,
+      "name": "Ildaeil Expander Inputs 8",
+      "description": "Expander to add 8 parameters CV inputs to Ildaeil",
+      "tags": [
+        "Expander"
+      ]
     }
   ]
 }

--- a/plugins/Cardinal/res/IldaeilExpIn8.svg
+++ b/plugins/Cardinal/res/IldaeilExpIn8.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="10.16mm"
+   height="128.5mm"
+   viewBox="0 0 10.16 128.5"
+   version="1.1"
+   id="svg4620"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="IldaeilExpIn8.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4614">
+    <linearGradient
+       gradientTransform="matrix(0.22222008,0,0,1,3.9539429e-7,168.49892)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient869"
+       id="linearGradient871"
+       x1="22.450642"
+       y1="0.64095056"
+       x2="22.450642"
+       y2="129.73215"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient869">
+      <stop
+         style="stop-color:#181919;stop-opacity:1;"
+         offset="0"
+         id="stop865" />
+      <stop
+         style="stop-color:#212222;stop-opacity:1"
+         offset="1"
+         id="stop867" />
+    </linearGradient>
+    <style
+       id="style6"
+       type="text/css">
+   
+    .str0 {stroke:#565656;stroke-width:0.0966867}
+    .str1 {stroke:#4F4F4F;stroke-width:0.193345}
+    .fil0 {fill:none}
+    .fil2 {fill:#2B2A29}
+    .fil1 {fill:#6B6B6B}
+   
+  </style>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="-94.129837"
+     inkscape:cy="240.67862"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0"
+     width="5.08mm"
+     units="in" />
+  <metadata
+     id="metadata4617">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-168.5)">
+    <rect
+       style="opacity:1;fill:url(#linearGradient871);fill-opacity:1;stroke-width:0.148422;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect815"
+       width="10.16"
+       height="128.49823"
+       x="0"
+       y="168.50089" />
+    <g
+       style="fill-rule:evenodd"
+       id="g5299"
+       transform="matrix(6.342689,0,0,6.342689,1.7430866,175.6457)">
+      <g
+         transform="translate(-1.6191379e-5,-0.08553947)"
+         id="Layer_x0020_1"
+         inkscape:label="Layer 1"
+         inkscape:groupmode="layer">
+        <metadata
+           id="CorelCorpID_0Corel-Layer" />
+        <circle
+           style="fill:none;stroke:#ffffff;stroke-width:0.0966867;stroke-opacity:1"
+           id="circle10"
+           r="0.15916"
+           cy="0.61075097"
+           cx="0.525226"
+           class="fil0 str0" />
+        <circle
+           style="fill:none;stroke:#ffffff;stroke-width:0.193345;stroke-opacity:1"
+           id="circle12"
+           r="0.42853901"
+           cy="0.61075097"
+           cx="0.525226"
+           class="fil0 str1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/plugins/Cardinal/src/Ildaeil.cpp
+++ b/plugins/Cardinal/src/Ildaeil.cpp
@@ -1445,7 +1445,7 @@ struct IldaeilWidget : ImGuiWidget, IdleCallback, Thread {
                 ImGui::SetKeyboardFocusHere();
             }
 
-            if (ImGui::InputText("", fPluginSearchString, sizeof(fPluginSearchString)-1,
+            if (ImGui::InputText("##pluginsearch", fPluginSearchString, sizeof(fPluginSearchString)-1,
                                  ImGuiInputTextFlags_CharsNoBlank|ImGuiInputTextFlags_AutoSelectAll))
                 fPluginSearchActive = true;
 
@@ -1463,7 +1463,7 @@ struct IldaeilWidget : ImGuiWidget, IdleCallback, Thread {
                 break;
             }
 
-            if (ImGui::Combo("", &current, pluginTypes, ARRAY_SIZE(pluginTypes)))
+            if (ImGui::Combo("##plugintypes", &current, pluginTypes, ARRAY_SIZE(pluginTypes)))
             {
                 fIdleState = kIdleChangePluginType;
                 switch (current)

--- a/plugins/Cardinal/src/Ildaeil.cpp
+++ b/plugins/Cardinal/src/Ildaeil.cpp
@@ -244,6 +244,9 @@ struct IldaeilModule : Module {
         NUM_LIGHTS
     };
 
+    // Expander
+    float leftMessages[2][8] = {};// messages from expander
+
 #ifndef HEADLESS
     SharedResourcePointer<JuceInitializer> juceInitializer;
 #endif
@@ -273,6 +276,16 @@ struct IldaeilModule : Module {
         : pcontext(static_cast<CardinalPluginContext*>(APP))
     {
         config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
+
+        leftExpander.producerMessage = leftMessages[0];
+        leftExpander.consumerMessage = leftMessages[1];
+        
+        // must init those that have no-connect info to non-connected, or else mother may read 0.0 init value if ever refresh limiters make it such that after a connection of expander the mother reads before the first pass through the expander's writing code, and this may do something undesired (ex: change track in Foundry on expander connected while track CV jack is empty) (comment originally in GateSeq64 by Marc Boulé)
+        for (uint i = 0; i < 8; ++i)
+        {
+            leftMessages[1][i] = std::numeric_limits<float>::quiet_NaN();
+        }
+
         for (uint i=0; i<2; ++i)
         {
             const char name[] = { 'A','u','d','i','o',' ','#',static_cast<char>('0'+i+1),'\0' };
@@ -1030,6 +1043,20 @@ struct IldaeilWidget : ImGuiWidget, IdleCallback, Thread {
             fileBrowserClose(fileBrowserHandle);
             fileBrowserHandle = nullptr;
         }
+        
+        if (fPluginGenericUI != nullptr && module->fCarlaHostHandle != nullptr) {
+            bool expanderPresent = (module->leftExpander.module && module->leftExpander.module->model == modelIldaeilExpIn8);
+            float *messagesFromExpander = (float*)module->leftExpander.consumerMessage;// could be invalid pointer when !expanderPresent, so read it only when expanderPresent
+            if (expanderPresent) {
+                for (uint i = 0; i < 8; i++) {
+                    if (i < fPluginGenericUI->parameterCount && module->leftExpander.module->inputs[i].isConnected()) {
+                        float scaled_param = (messagesFromExpander[i] + 10.0) * (fPluginGenericUI->parameters[i].max - fPluginGenericUI->parameters[i].min) / (20.0 + fPluginGenericUI->parameters[i].min);
+                        fPluginGenericUI->values[i] = scaled_param;
+                        carla_set_parameter_value(module->fCarlaHostHandle, 0, 0, scaled_param);
+                    }
+                }
+            }
+        }        
 
         if (fDrawingState == kDrawingPluginGenericUI && fPluginGenericUI != nullptr && fPluginHasOutputParameters)
         {

--- a/plugins/Cardinal/src/IldaeilExpIn8.cpp
+++ b/plugins/Cardinal/src/IldaeilExpIn8.cpp
@@ -1,0 +1,85 @@
+//Expander module for Ildaeil
+//
+//Based on code from GateSeq64 and GateSeq64Expander by Marc Boulé
+//Adapted for Ildaeil by Simon-L
+
+#include "plugin.hpp"
+
+static const unsigned int ildaeil_expanderRefreshStepSkips = 4;
+
+struct IldaeilExpIn8 : Module {
+	enum InputIds {
+		PARAM1_INPUT,
+		PARAM2_INPUT,
+		PARAM3_INPUT,
+		PARAM4_INPUT,
+		PARAM5_INPUT,
+		PARAM6_INPUT,
+		PARAM7_INPUT,
+		PARAM8_INPUT,
+		NUM_INPUTS
+	};
+
+	// Expander
+	float rightMessages[2][2] = {};// messages from Ildaeil
+
+	unsigned int expanderRefreshCounter = 0;	
+
+	IldaeilExpIn8() {
+		config(0, NUM_INPUTS, 0, 0);
+		
+		rightExpander.producerMessage = rightMessages[0];
+		rightExpander.consumerMessage = rightMessages[1];
+		
+		configInput(PARAM1_INPUT, "Parameter 1");
+		configInput(PARAM2_INPUT, "Parameter 2");
+		configInput(PARAM3_INPUT, "Parameter 3");
+		configInput(PARAM4_INPUT, "Parameter 4");
+		configInput(PARAM5_INPUT, "Parameter 5");
+		configInput(PARAM6_INPUT, "Parameter 6");
+		configInput(PARAM7_INPUT, "Parameter 7");
+		configInput(PARAM8_INPUT, "Parameter 8");
+
+	}
+
+
+	void process(const ProcessArgs &args) override {		
+		bool ildaeilPresent = (rightExpander.module && rightExpander.module->model == modelIldaeil);
+		if (ildaeilPresent) {
+			float *messagesToIldaeil = (float*)rightExpander.module->leftExpander.producerMessage;
+			for (int i = 0; i < NUM_INPUTS; i++) {
+				messagesToIldaeil[i] = (inputs[i].isConnected() ? inputs[i].getVoltage() : std::numeric_limits<float>::quiet_NaN());
+			}
+			rightExpander.module->leftExpander.messageFlipRequested = true;
+		}		
+	}// process()
+};
+
+
+struct IldaeilExpIn8Widget : ModuleWidget {
+	IldaeilExpIn8Widget(IldaeilExpIn8 *module) {
+		setModule(module);
+	
+        setPanel(APP->window->loadSvg(asset::plugin(pluginInstance, "res/IldaeilExpIn8.svg")));
+        box.size = Vec(RACK_GRID_WIDTH * 2, RACK_GRID_HEIGHT);
+
+        // Screws
+        addChild(createWidget<ScrewBlack>(Vec(0, 0)));
+        addChild(createWidget<ScrewBlack>(Vec(0, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
+        addChild(createWidget<ScrewBlack>(Vec(RACK_GRID_WIDTH, 0)));
+        addChild(createWidget<ScrewBlack>(Vec(RACK_GRID_WIDTH, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
+
+        // Inputs
+		addInput(createInput<PJ301MPort>(Vec(3, 54 + 75), module, IldaeilExpIn8::PARAM1_INPUT));
+		addInput(createInput<PJ301MPort>(Vec(3, 54 + 105), module, IldaeilExpIn8::PARAM2_INPUT));
+		addInput(createInput<PJ301MPort>(Vec(3, 54 + 135), module, IldaeilExpIn8::PARAM3_INPUT));
+        addInput(createInput<PJ301MPort>(Vec(3, 54 + 165), module, IldaeilExpIn8::PARAM4_INPUT));
+        addInput(createInput<PJ301MPort>(Vec(3, 54 + 195), module, IldaeilExpIn8::PARAM5_INPUT));
+        addInput(createInput<PJ301MPort>(Vec(3, 54 + 225), module, IldaeilExpIn8::PARAM6_INPUT));
+        addInput(createInput<PJ301MPort>(Vec(3, 54 + 255), module, IldaeilExpIn8::PARAM7_INPUT));
+        addInput(createInput<PJ301MPort>(Vec(3, 54 + 285), module, IldaeilExpIn8::PARAM8_INPUT));
+	}
+
+};
+
+Model *modelIldaeilExpIn8 = createModel<IldaeilExpIn8, IldaeilExpIn8Widget>("IldaeilExpIn8");

--- a/plugins/Cardinal/src/plugin.hpp
+++ b/plugins/Cardinal/src/plugin.hpp
@@ -34,3 +34,4 @@ extern Model* modelHostCV;
 extern Model* modelHostParameters;
 extern Model* modelHostTime;
 extern Model* modelIldaeil;
+extern Model* modelIldaeilExpIn8;

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -186,6 +186,7 @@ PLUGIN_FILES += Cardinal/src/HostCV.cpp
 PLUGIN_FILES += Cardinal/src/HostParameters.cpp
 PLUGIN_FILES += Cardinal/src/HostTime.cpp
 PLUGIN_FILES += Cardinal/src/Ildaeil.cpp
+PLUGIN_FILES += Cardinal/src/IldaeilExpIn8.cpp
 
 ifneq ($(HEADLESS),true)
 PLUGIN_FILES += Cardinal/src/ImGuiWidget.cpp

--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -643,6 +643,7 @@ static void initStatic__Cardinal()
         p->addModel(modelHostParameters);
         p->addModel(modelHostTime);
         p->addModel(modelIldaeil);
+        p->addModel(modelIldaeilExpIn8);
     }
 }
 


### PR DESCRIPTION
Pretty basic for now, 8 parameters of the loaded plugin can be automated.
If inputs are connected, the expander "steals" the UI control, if unconnected, the user controls it.

Note that this is a *left*-side expander.
There has been some discussion about using the more common convention of right side.

I've made it left-side to experiment with the pattern of constructing chains of expanding modules: here this expander adds (parameters) inputs to the left, and future expanders for outputs could use the right side.

@falkTX I'm opening it right now merely for you to check the code in Ildaeil when you got some time

TODO:
- Mark the parameter visually in the UI when the expander "stole" it.
- Mark the inputs (red/green leds?) on the expander when there is a matching parameter in the plugin (to handle case where plugin has less than 8 parameters)