### PR TITLE
[Incompatible] Add Geodesics modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -139,3 +139,6 @@
 [submodule "plugins/Autinn"]
 	path = plugins/Autinn
 	url = https://github.com/NikolaiVChr/Autinn.git
+[submodule "plugins/Geodesics"]
+	path = plugins/Geodesics
+	url = https://github.com/MarcBoule/Geodesics.git

--- a/doc/LICENSES.md
+++ b/doc/LICENSES.md
@@ -29,6 +29,7 @@ Bellow follows a list of all code licenses used in Cardinal and linked submodule
 | ExpertSleepers Encoders | MIT                   | |
 | Extratone               | GPL-3.0-or-later      | |
 | Fehler Fabrik           | GPL-3.0-or-later      | |
+| Geodesics               | GPL-3.0               | (blocker for inclusion right now)  |
 | Glue the Giant          | GPL-3.0-or-later      | |
 | Grande                  | GPL-3.0-or-later      | |
 | HetrickCV               | CC0-1.0               | |

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -479,6 +479,11 @@ FUNDAMENTAL_CUSTOM = $(DRWAV)
 endif
 
 # --------------------------------------------------------------
+# Geodesics
+
+PLUGIN_FILES += $(filter-out Geodesics/src/plugin.cpp,$(wildcard Geodesics/src/*.cpp))
+
+# --------------------------------------------------------------
 # GlueTheGiant
 
 PLUGIN_FILES += $(filter-out GlueTheGiant/src/plugin.cpp,$(wildcard GlueTheGiant/src/*.cpp))
@@ -1128,6 +1133,16 @@ $(BUILD_DIR)/Fundamental/%.cpp.o: Fundamental/%.cpp
 	$(SILENT)$(CXX) $< $(BUILD_CXX_FLAGS) -c -o $@ \
 		$(foreach m,$(FUNDAMENTAL_CUSTOM),$(call custom_module_names,$(m),Fundamental)) \
 		-DpluginInstance=pluginInstance__Fundamental
+
+$(BUILD_DIR)/Geodesics/%.cpp.o: Geodesics/%.cpp
+	-@mkdir -p "$(shell dirname $(BUILD_DIR)/$<)"
+	@echo "Compiling $<"
+	$(SILENT)$(CXX) $< $(BUILD_CXX_FLAGS) -c -o $@ \
+		$(foreach m,$(GEODESICS_CUSTOM),$(call custom_module_names,$(m),Geodesics)) \
+		-DpluginInstance=pluginInstance__Geodesics \
+		-DsaveDarkAsDefault=saveDarkAsDefault__Geodesics \
+		-DisDark=isDark__Geodesics \
+		-Dinit=init__Geodesics
 
 $(BUILD_DIR)/GlueTheGiant/%.cpp.o: GlueTheGiant/%.cpp
 	-@mkdir -p "$(shell dirname $(BUILD_DIR)/$<)"

--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -309,6 +309,9 @@ void setupSamples();
 #include "Fundamental/src/plugin.hpp"
 #endif
 
+// Geodesics
+#include "Geodesics/src/Geodesics.hpp"
+
 // GlueTheGiant
 #include "GlueTheGiant/src/plugin.hpp"
 bool audition_mixer = false;
@@ -568,6 +571,7 @@ Plugin* pluginInstance__FehlerFabrik;
 #ifdef WITH_FUNDAMENTAL
 Plugin* pluginInstance__Fundamental;
 #endif
+extern Plugin* pluginInstance__Geodesics;
 Plugin* pluginInstance__GrandeModular;
 Plugin* pluginInstance__GlueTheGiant;
 Plugin* pluginInstance__HetrickCV;
@@ -1460,6 +1464,27 @@ static void initStatic__Fundamental()
 }
 #endif
 
+static void initStatic__Geodesics()
+{
+    Plugin* const p = new Plugin;
+    pluginInstance__Geodesics = p;
+
+    const StaticPluginLoader spl(p, "Geodesics");
+    if (spl.ok())
+    {
+        p->addModel(modelBlackHoles);
+        p->addModel(modelPulsars);
+        p->addModel(modelBranes);
+        p->addModel(modelIons);
+        p->addModel(modelEntropia);
+        p->addModel(modelEnergy);
+        p->addModel(modelTorus);
+        p->addModel(modelFate);
+        p->addModel(modelBlankLogo);
+        p->addModel(modelBlankInfo);
+    }
+}
+
 static void initStatic__GlueTheGiant()
 {
     Plugin* const p = new Plugin;
@@ -2003,6 +2028,7 @@ void initStaticPlugins()
    #ifdef WITH_FUNDAMENTAL
     initStatic__Fundamental();
    #endif
+    initStatic__Geodesics();
     initStatic__GlueTheGiant();
     initStatic__GrandeModular();
     initStatic__HetrickCV();

--- a/plugins/todo.txt
+++ b/plugins/todo.txt
@@ -22,9 +22,6 @@ https://github.com/squinkylabs/SquinkyVCV
 
 LindenbergResearch        43959.0 (not opensource?)
 
-Geodesics                 42761.0
-https://github.com/MarcBoule/Geodesics
-
 Alikins                   41798.0
 https://github.com/alikins/Alikins-rack-plugins
 


### PR DESCRIPTION
Adding them was straightforward. A few symbols resulted in duplicates
when linking, hence the extra "-D" hackery in the plugins Makefile.