### PR TITLE
change defaults in HostMIDI.cpp

### DIFF
--- a/plugins/Cardinal/src/HostMIDI.cpp
+++ b/plugins/Cardinal/src/HostMIDI.cpp
@@ -143,10 +143,10 @@ struct HostMIDI : TerminalModule {
             lastProcessCounter = 0;
             wasPlaying = false;
             channel = 0;
-            smooth = true;
+            smooth = false;
             channels = 1;
             polyMode = ROTATE_MODE;
-            pwRange = 2;
+            pwRange = 0;
             panic();
         }
 


### PR DESCRIPTION
disable mw/pw smoothing by default, set pwRange to zero so it doesn't unexpectedly affect V/OCT (restores behaviour of previous releases)