### PR TITLE
Decrease scrolling speed to Rack's default on macOS

### DIFF
--- a/src/CardinalUI.cpp
+++ b/src/CardinalUI.cpp
@@ -647,9 +647,7 @@ protected:
     bool onScroll(const ScrollEvent& ev) override
     {
         rack::math::Vec scrollDelta = rack::math::Vec(ev.delta.getX(), ev.delta.getY());
-#ifdef DISTRHO_OS_MAC
-        scrollDelta = scrollDelta.mult(10.0);
-#else
+#ifndef DISTRHO_OS_MAC
         scrollDelta = scrollDelta.mult(50.0);
 #endif
 


### PR DESCRIPTION
Cardinal inherits scroll value multiplication from Rack, but because of differences in GUI stack on macOS we get scrolling speed that is way over the top (x10 comparing to Rack, where it is somewhat optimal, at least scrolling using trackpad feels natural and consistent with other applications). And this dramatically worsens user experience (at least it is how it was for me, most likely for others too).