### PR TITLE
Adding plugin Sapphire, modules Elastika, Moots.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -227,3 +227,6 @@
 [submodule "plugins/surgext"]
 	path = plugins/surgext
 	url = https://github.com/surge-synthesizer/surge-rack.git
+[submodule "plugins/Sapphire"]
+	path = plugins/Sapphire
+	url = https://github.com/cosinekitty/sapphire.git

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ At the moment the following 3rd-party modules are provided:
 - rackwindows
 - RebelTech
 - repelzen
+- Sapphire
 - Sonus Modular
 - stocaudio
 - Stoermelder Pack-One

--- a/docs/LICENSES.md
+++ b/docs/LICENSES.md
@@ -73,6 +73,7 @@ Bellow follows a list of all code licenses used in Cardinal and linked submodule
 | Rackwindows             | MIT                      | |
 | repelzen                | GPL-3.0-or-later         | |
 | RebelTech               | GPL-2.0-or-later         | |
+| Sapphire                | GPL-3.0-or-later         | |
 | Sonus Modular           | GPL-3.0-or-later         | |
 | stocaudio               | GPL-3.0-or-later         | |
 | Stoermelder Pack-One    | GPL-3.0-or-later         | |
@@ -212,6 +213,7 @@ Below is a list of artwork licenses from plugins
 | Rackwindows/*                           | MIT              | [Same license as source code](https://github.com/n0jo/rackwindows/issues/15) |
 | repelzen/*                              | CC-BY-SA-4.0     | |
 | RebelTech/*                             | CC-BY-NC-4.0     | |
+| Sapphire/*                              | GPL-3.0-or-later | No artwork specific license provided |
 | sonusmodular/*                          | GPL-3.0-or-later | [Same license as source code](https://gitlab.com/sonusdept/sonusmodular/-/issues/14) |
 | stocaudio/*                             | GPL-3.0-or-later | No artwork specific license provided |
 | stoermelder-packone/*                   | GPL-3.0-or-later | No artwork specific license provided |

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -893,6 +893,11 @@ PLUGIN_FILES += $(filter-out repelzen/src/repelzen.cpp,$(wildcard repelzen/src/*
 REPELZEN_CUSTOM = Blank Mixer Werner tanh_pade
 
 # --------------------------------------------------------------
+# Sapphire
+
+PLUGIN_FILES += $(filter-out Sapphire/src/plugin.cpp,$(wildcard Sapphire/src/*.cpp))
+
+# --------------------------------------------------------------
 # sonusmodular
 
 PLUGIN_FILES += $(filter-out sonusmodular/src/sonusmodular.cpp,$(wildcard sonusmodular/src/*.cpp))
@@ -2112,6 +2117,13 @@ $(BUILD_DIR)/repelzen/%.cpp.o: repelzen/%.cpp
 	$(SILENT)$(CXX) $< $(BUILD_CXX_FLAGS) -c -o $@ \
 		$(foreach m,$(REPELZEN_CUSTOM),$(call custom_module_names,$(m),repelzen)) \
 		-DpluginInstance=pluginInstance__repelzen
+
+$(BUILD_DIR)/Sapphire/%.cpp.o: Sapphire/%.cpp
+	-@mkdir -p "$(shell dirname $(BUILD_DIR)/$<)"
+	@echo "Compiling $<"
+	$(SILENT)$(CXX) $< $(BUILD_CXX_FLAGS) -c -o $@ \
+		$(foreach m,$(SAPPHIRE_CUSTOM),$(call custom_module_names,$(m),Sapphire)) \
+		-DpluginInstance=pluginInstance__sapphire
 
 $(BUILD_DIR)/sonusmodular/%.cpp.o: sonusmodular/%.cpp
 	-@mkdir -p "$(shell dirname $(BUILD_DIR)/$<)"

--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -716,6 +716,9 @@ void addThemeMenuItems(Menu*, ModuleTheme*) {}
 #undef modelWerner
 #undef tanh_pade
 
+// Sapphire
+#include "Sapphire/src/plugin.hpp"
+
 // sonusmodular
 #include "sonusmodular/src/sonusmodular.hpp"
 
@@ -850,6 +853,7 @@ Plugin* pluginInstance__Prism;
 Plugin* pluginInstance__rackwindows;
 Plugin* pluginInstance__RebelTech;
 Plugin* pluginInstance__repelzen;
+Plugin* pluginInstance__sapphire;
 Plugin* pluginInstance__sonusmodular;
 Plugin* pluginInstance__stocaudio;
 extern Plugin* pluginInstance__stoermelder_p1;
@@ -2729,6 +2733,19 @@ static void initStatic__repelzen()
     }
 }
 
+static void initStatic__Sapphire()
+{
+    Plugin* const p = new Plugin;
+    pluginInstance__sapphire = p;
+
+    const StaticPluginLoader spl(p, "Sapphire");
+    if (spl.ok())
+    {
+        p->addModel(modelElastika);
+        p->addModel(modelMoots);
+    }
+}
+
 static void initStatic__sonusmodular()
 {
     Plugin* const p = new Plugin;
@@ -3100,6 +3117,7 @@ void initStaticPlugins()
     initStatic__rackwindows();
     initStatic__RebelTech();
     initStatic__repelzen();
+    initStatic__Sapphire();
     initStatic__sonusmodular();
     initStatic__stocaudio();
     initStatic__stoermelder_p1();


### PR DESCRIPTION
I was able to get Sapphire integrated and working in Cardinal.

![image](https://user-images.githubusercontent.com/11699954/206052384-897d4314-ad42-4efa-a604-953dfe292f17.png)

I notice the CPU overhead of Elastika is much higher than I encounter in VCV Rack. Elastika does quite a bit of SIMD number crunching. Is there something special I need to do in order to get that working in Cardinal also? Thanks!