### PR TITLE
Add support for setting host parameters in OSC

### DIFF
--- a/src/CardinalCommon.cpp
+++ b/src/CardinalCommon.cpp
@@ -310,6 +310,29 @@ static int osc_param_handler(const char*, const char* types, lo_arg** argv, int 
     return 0;
 }
 
+static int osc_host_param_handler(const char*, const char* types, lo_arg** argv, int argc, const lo_message m, void* const self)
+{
+    d_debug("osc_host_param_handler()");
+    DISTRHO_SAFE_ASSERT_RETURN(argc == 2, 0);
+    DISTRHO_SAFE_ASSERT_RETURN(types != nullptr, 0);
+    DISTRHO_SAFE_ASSERT_RETURN(types[0] == 'i', 0);
+    DISTRHO_SAFE_ASSERT_RETURN(types[1] == 'f', 0);
+
+    if (CardinalBasePlugin* const plugin = static_cast<Initializer*>(self)->remotePluginInstance)
+    {
+        CardinalPluginContext* const context = plugin->context;
+
+        const int paramId = argv[0]->i;
+        const float paramValue = argv[1]->f;
+
+        if (0 <= paramId && (uint)paramId < kModuleParameterCount) {
+          context->parameters[paramId] = paramValue;
+        }
+    }
+
+    return 0;
+}
+
 static int osc_screenshot_handler(const char*, const char* types, lo_arg** argv, int argc, const lo_message m, void* const self)
 {
     d_debug("osc_screenshot_handler()");
@@ -483,6 +506,7 @@ Initializer::Initializer(const CardinalBasePlugin* const plugin, const CardinalB
     DISTRHO_SAFE_ASSERT_RETURN(oscServerThread != nullptr,);
 
     lo_server_thread_add_method(oscServerThread, "/hello", "", osc_hello_handler, this);
+    lo_server_thread_add_method(oscServerThread, "/host-param", "if", osc_host_param_handler, this);
     lo_server_thread_add_method(oscServerThread, "/load", "b", osc_load_handler, this);
     lo_server_thread_add_method(oscServerThread, "/param", "hif", osc_param_handler, this);
     lo_server_thread_add_method(oscServerThread, "/screenshot", "b", osc_screenshot_handler, this);


### PR DESCRIPTION
This is meant to be used by e.g. small electronic widgets providing live values from potentiometers, switches, …