### PR TITLE
Carla.cpp and Ildaeil.cpp: check /usr directory for existing binary

### DIFF
--- a/plugins/Cardinal/src/Carla.cpp
+++ b/plugins/Cardinal/src/Carla.cpp
@@ -143,6 +143,16 @@ struct CarlaModule : Module {
             binaryDir = "/Applications/Carla.app/Contents/MacOS";
             resourceDir = "/Applications/Carla.app/Contents/MacOS/resources";
         }
+        else if (system:exists("/usr/local/bin/carla"))
+        {
+            binraryDir = "/usr/local/bin/carla";
+            resourceDir = "/usr/local/share/carla/resources";
+        }
+        else if (system:exists("/usr/bin/carla"))
+        {
+            binaryDir = "/usr/bin/carla";
+            resourceDir = "/usr/share/carla/resources";
+        }
 #elif defined(CARLA_OS_WIN)
         const std::string winBinaryDir = system::join(asset::systemDir, "Carla");
 

--- a/plugins/Cardinal/src/Ildaeil.cpp
+++ b/plugins/Cardinal/src/Ildaeil.cpp
@@ -255,6 +255,16 @@ struct IldaeilModule : Module {
             carla_set_engine_option(fCarlaHostHandle, ENGINE_OPTION_PATH_BINARIES, 0, "/Applications/Carla.app/Contents/MacOS");
             carla_set_engine_option(fCarlaHostHandle, ENGINE_OPTION_PATH_RESOURCES, 0, "/Applications/Carla.app/Contents/MacOS/resources");
         }
+        else if (system::exists("/usr/local/bin/carla"))
+        {
+            carla_set_engine_option(fCarlaHostHandle, ENGINE_OPTION_PATH_BINARIES, 0, "/usr/local/bin/carla");
+            carla_set_engine_option(fCarlaHostHandle, ENGINE_OPTION_PATH_RESOURCES, 0, "/usr/local/share/carla/resources");
+        }
+        else if (system::exists("/usr/bin/carla"))
+        {
+            carla_set_engine_option(fCarlaHostHandle, ENGINE_OPTION_PATH_BINARIES, 0, "/usr/bin/carla");
+            carla_set_engine_option(fCarlaHostHandle, ENGINE_OPTION_PATH_RESOURCES, 0, "/usr/share/carla/resources");
+        }
 #elif defined(CARLA_OS_WASM)
         if (true)
         {}


### PR DESCRIPTION
When using [Homebrew](https://brew.sh) to download carla and build from source (instead of from https://github.com/falkTX/Carla-Releases/releases), there won't be a `Carla.app` in `~/Applications` or `/Applications`, but the binaries do exist under `/usr/local/bin`. Thus, modules like Carla will report that "Carla is not installed on this system" because it only checks for `Carla.app`.