### PR TITLE
reinit random in case plugin was initialized on another thread

### DIFF
--- a/src/override/Engine.cpp
+++ b/src/override/Engine.cpp
@@ -758,6 +758,8 @@ void Engine::addModule(Module* module) {
 	DISTRHO_SAFE_ASSERT_RETURN(it == internal->modules.end(),);
 	auto tit = std::find(internal->terminalModules.begin(), internal->terminalModules.end(), module);
 	DISTRHO_SAFE_ASSERT_RETURN(tit == internal->terminalModules.end(),);
+	// Reinitialize random module since it uses thread-local RNG state
+	random::init();
 	// Set ID if unset or collides with an existing ID
 	while (module->id < 0 || internal->modulesCache.find(module->id) != internal->modulesCache.end()) {
 		// Randomly generate ID
@@ -1003,6 +1005,8 @@ void Engine::addCable(Cable* cable) {
 		if (cable2->outputModule == cable->outputModule && cable2->outputId == cable->outputId)
 			outputWasConnected = true;
 	}
+	// Reinitialize random module since it uses thread-local RNG state
+	random::init();
 	// Set ID if unset or collides with an existing ID
 	while (cable->id < 0 || internal->cablesCache.find(cable->id) != internal->cablesCache.end()) {
 		// Randomly generate ID


### PR DESCRIPTION
Hey there DISTRHO folks, 

The random module uses a thread-local RNG state, making an assumption that the initialization will always occur on the same thread that the random functions are called from. I think this is not a safe assumption to make in a plugin context because the plugin might not be instantiated on the same thread as the UI code that calls these functions. I guess most plugins assume the host is instantiating plugins on the UI thread.

Ran into this when trying to use Cardinal in my host, and adding a new module or cable would cause that while loop to spin forever since random::u64() was returning 0. I know this is just a band-aid fix, it would be easy to forget to add this in other places where the random module is used (I didn't go looking outside this Engine.cpp file). Maybe you have a better way, but this fixed the issue for me at least.

Thanks for Cardinal!