### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -22,16 +22,10 @@ body:
         - VST3
     validations:
       required: true
-  - type: dropdown
+  - type: input
     id: os
     attributes:
       label: OS
-      multiple: true
-      options:
-        - FreeBSD
-        - Linux
-        - macOS
-        - Windows
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,42 @@
+name: Bug Report
+description: Report a bug with Cardinal
+body:
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      placeholder: "23.07"
+    validations:
+      required: true
+  - type: dropdown
+    id: plugin-type
+    attributes:
+      label: Plugin type
+      multiple: true
+      options:
+        - Native
+        - AU
+        - CLAP
+        - LV2
+        - VST2
+        - VST3
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      multiple: true
+      options:
+        - FreeBSD
+        - Linux
+        - macOS
+        - Windows
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Description
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -5,7 +5,7 @@ body:
     id: version
     attributes:
       label: Version
-      placeholder: "23.07"
+      value: "23.10"
     validations:
       required: true
   - type: dropdown
@@ -34,6 +34,12 @@ body:
         - Windows
     validations:
       required: true
+  - type: input
+    id: daw-host
+    attributes:
+      label: "DAW / host"
+    validations:
+      required: false
   - type: textarea
     id: bug-description
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Module request
+    url: https://github.com/DISTRHO/Cardinal/wiki/Possible-modules-to-include
+    about: To request a new module, add it to the wiki page here
+  - name: Discussions
+    url: https://github.com/DISTRHO/Cardinal/discussions
+    about: Ask other questions or share what you've made with Cardinal

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,9 @@
+name: Feature request
+description: Request a new feature
+body:
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Description
+    validations:
+      required: true


### PR DESCRIPTION
Just a simple template to ensure version, plugin type, OS, and DAW/host are mentioned in bug reports.

## Previews

[New issue menu](https://github.com/jn64/Cardinal/issues/new/choose)

[Bug report form](https://github.com/jn64/Cardinal/issues/new?template=bug.yaml)

The dropdown for plugin type allows multiple selections.

[Example bug report](https://github.com/jn64/Cardinal/issues/1)