### PR TITLE
Sapphire 2.3.0 adds modules Frolic, Tricorder, Tin.

### DIFF
--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -2769,7 +2769,10 @@ static void initStatic__Sapphire()
     if (spl.ok())
     {
         p->addModel(modelElastika);
+        p->addModel(modelFrolic);
         p->addModel(modelMoots);
+        p->addModel(modelTin);
+        p->addModel(modelTricorder);
         p->addModel(modelTubeUnit);
     }
 }


### PR DESCRIPTION
Adds three new modules to the Sapphire plugin in version 2.3.0:
* Frolic: a 3D chaotic oscillator
* Tricorder: a 3D oscilloscope that works with Frolic or Tin.
* Tin: a generic 3D input to feed any 3 voltages you want into Tricorder.