### PR TITLE
Sapphire v2.4.2

### DIFF
--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -2871,8 +2871,12 @@ static void initStatic__Sapphire()
         p->addModel(modelElastika);
         p->addModel(modelFrolic);
         p->addModel(modelGlee);
+        p->addModel(modelHiss);
         p->addModel(modelMoots);
+        p->addModel(modelNucleus);
+        p->addModel(modelPolynucleus);
         p->addModel(modelTin);
+        p->addModel(modelTout);
         p->addModel(modelTricorder);
         p->addModel(modelTubeUnit);
     }


### PR DESCRIPTION
The following is a summary of changes between Sapphire versions 2.3.0 and 2.4.2. See the Sapphire project change log for a more complete and detailed list:

https://github.com/cosinekitty/sapphire/blob/main/CHANGELOG.md

EDIT: Corrected mistakes in the list...

Added <s>5</s> 4 new modules:
* <s>Glee: a chaotic oscillator counterpart for Frolic</s>
* Hiss: a 3D vector generator with unbiased directionality
* Nucleus: complex audio generator using physical simulation of electromagnetic particles
* Polynucleus: a version of Nucleus with vector-oriented polymorphic ports
* Tout (Tricorder OUTput): right-extender module for extracting a vector stream from Tricorder

Lots of improvements to Tricorder.
* Smoother animation
* Configurable axis rotation speed
* Other minor fixes and improvements

Bug fix: Elastika and TubeUnit now save and load Automatic Gain Control settings as part of the patch.

Added a context menu option in each attenuverter knob for a 10X low-sensitivity mode. An orange dot appears on the knob to indicate low sensitivity.