### PR TITLE
Sapphire v2.4.4

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -2684,7 +2684,7 @@ $(BUILD_DIR)/repelzen/%.cpp.o: repelzen/%.cpp
 $(BUILD_DIR)/Sapphire/%.cpp.o: Sapphire/%.cpp
 	-@mkdir -p "$(shell dirname $(BUILD_DIR)/$<)"
 	@echo "Compiling $<"
-	$(SILENT)$(CXX) $< $(BUILD_CXX_FLAGS) -c -o $@ \
+	$(SILENT)$(CXX) $< $(BUILD_CXX_FLAGS) -std=gnu++17 -c -o $@ \
 		$(foreach m,$(SAPPHIRE_CUSTOM),$(call custom_module_names,$(m),Sapphire)) \
 		-DpluginInstance=pluginInstance__sapphire
 


### PR DESCRIPTION
This brings Cardinal in sync with VCV Rack at Sapphire v2.4.4. Minor UI improvements.

Corrected C++17 build problems for the Sapphire plugin: I learned not to put anything fancy in plugin.cpp or plugin.hpp! Cardinal's C++11 code must be able to include plugins/Sapphire/plugin.hpp, so I can't put any C++17 code there.

This frees me up to use std::clamp, std::make_unique, etc.