### PR TITLE
Update FAQ section about save file dialogs

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -56,16 +56,22 @@ Note that this applies to all DPF-based plugins and not just Cardinal.
 
 ## On BSD/Linux/X11 the menu item "Save As/Export..." does nothing
 
-The save-file dialogs in Cardinal requires a working [xdg-desktop-portal](https://github.com/flatpak/xdg-desktop-portal) DBus implementation from your desktop environment.  
-Typically your desktop already provides this, if not consider looking for a package to install with "desktop-portal" in the name.  
-If you are running a window manager without a "real" desktop environment (like custom X11 or i3 setups),
-you will need to manually activate the systemd unit that provides these DBus services, like so:
+Cardinal relies on [xdg-desktop-portal](https://github.com/flatpak/xdg-desktop-portal)
+for save file dialogs. Typically a desktop environment (DE) handles this,
+lightweight setups without DEs may require extra work.
 
-```
-systemctl enable xdg-desktop-portal --user --now
+To make the dialogs appear, first install `xdg-desktop-portal` and one of its
+backends (`xdg-desktop-portal-gtk` is a good default option). Then you'll need
+to set up environment variables for portal to work, like this:
+
+```bash
+dbus-update-activation-environment --systemd DBUS_SESSION_BUS_ADDRESS DISPLAY XAUTHORITY
 ```
 
-Note: The open-file dialogs in Cardinal do not have this restriction, with a fallback in case the desktop portal is not available.
+It's recommended that you add this command to `~/.xinitrc` so that runs
+automatically every time you boot your system.
+
+For further discussion, see [this issue](https://github.com/DISTRHO/Cardinal/issues/135).
 
 ## Why IRC and not Discord?
 


### PR DESCRIPTION
This PR updates the suggested method to fix the Save FIle dialog according to this comment: https://github.com/DISTRHO/Cardinal/issues/135#issuecomment-1659151269. The current suggestion doesn't fix the problem and results in the following error.

```bash
$ systemctl enable xdg-desktop-portal --user --now
The unit files have no installation config (WantedBy=, RequiredBy=, UpheldBy=,
Also=, or Alias= settings in the [Install] section, and DefaultInstance= for
template units). This means they are not meant to be enabled or disabled using systemctl.
 
Possible reasons for having these kinds of units are:
• A unit may be statically enabled by being symlinked from another unit's
  .wants/, .requires/, or .upholds/ directory.
• A unit's purpose may be to act as a helper for some other unit which has
  a requirement dependency on it.
• A unit may be started when needed via activation (socket, path, timer,
  D-Bus, udev, scripted systemctl call, ...).
• In case of template units, the unit is meant to be enabled with some
  instance name specified.
```

The suggestion introduced in this PR seems to be a proper workaround for the issue.

I've also removed the note about the "Open" dialog because it turned out to be wrong for me: the "Open" dialog didn't appear until I applied the fix.