### PR TITLE
Update Sapphire plugin from v2.4.4 to v2.4.8.

### DIFF
--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -3074,17 +3074,20 @@ static void initStatic__Sapphire()
     const StaticPluginLoader spl(p, "Sapphire");
     if (spl.ok())
     {
-        p->addModel(modelElastika);
-        p->addModel(modelFrolic);
-        p->addModel(modelGlee);
-        p->addModel(modelHiss);
-        p->addModel(modelMoots);
-        p->addModel(modelNucleus);
-        p->addModel(modelPolynucleus);
-        p->addModel(modelTin);
-        p->addModel(modelTout);
-        p->addModel(modelTricorder);
-        p->addModel(modelTubeUnit);
+        p->addModel(modelSapphireElastika);
+        p->addModel(modelSapphireFrolic);
+        p->addModel(modelSapphireGalaxy);
+        p->addModel(modelSapphireGlee);
+        p->addModel(modelSapphireHiss);
+        p->addModel(modelSapphireMoots);
+        p->addModel(modelSapphireNucleus);
+        p->addModel(modelSapphirePivot);
+        p->addModel(modelSapphirePolynucleus);
+        p->addModel(modelSapphireRotini);
+        p->addModel(modelSapphireTin);
+        p->addModel(modelSapphireTout);
+        p->addModel(modelSapphireTricorder);
+        p->addModel(modelSapphireTubeUnit);
     }
 }
 


### PR DESCRIPTION
Added the following new modules:
- Galaxy: a clone of Airwindows Galactic reverb by Chris Johnson.
- Pivot: an operator that allows reorienting a vector in 3D space.
- Rotini: an operator that takes the cross product of a pair of 3D vectors.

Improvements to chaos generators:
- Glee now has 4 different chaos modes, selectable by right-clicking the CHAOS knob.
- Frolic and Glee now have a *turbo mode* option in the right-click menu for the SPEED knob. It allows audio-rate chaotic signals, but it comes with a CPU cost.

Other changes:
- Tube Unit: support low-sensitivity attenuverter knobs.
- Elastika, Nucleus, Polynucleus: right-click menu to toggle sensitivity on all attenuverter knobs.
- Elastika: allow sending either left or right output particle's position vector to Tricorder for 3D display.