### PR TITLE
re-apply scroll multiplier for all OSes

### DIFF
--- a/src/CardinalUI.cpp
+++ b/src/CardinalUI.cpp
@@ -1041,7 +1041,8 @@ protected:
         if (inSelfTest) return false;
        #endif
 
-        const rack::math::Vec scrollDelta = rack::math::Vec(-ev.delta.getX(), ev.delta.getY());
+        rack::math::Vec scrollDelta = rack::math::Vec(-ev.delta.getX(), ev.delta.getY());
+        scrollDelta = scrollDelta.mult(50.0);
 
         const int mods = glfwMods(ev.mod);
         const ScopedContext sc(this, mods);

--- a/src/CardinalUI.cpp
+++ b/src/CardinalUI.cpp
@@ -1041,8 +1041,7 @@ protected:
         if (inSelfTest) return false;
        #endif
 
-        rack::math::Vec scrollDelta = rack::math::Vec(-ev.delta.getX(), ev.delta.getY());
-        scrollDelta = scrollDelta.mult(50.0);
+        const rack::math::Vec scrollDelta = rack::math::Vec(-ev.delta.getX(), ev.delta.getY()) * 50 ;
 
         const int mods = glfwMods(ev.mod);
         const ScopedContext sc(this, mods);


### PR DESCRIPTION
Seems to do the trick!

`50` might be a tad too high, but went down to `40` and it seems sluggish again so I think `50` is good.

This resolves https://github.com/DISTRHO/Cardinal/issues/572