### PR TITLE
Update DIFFERENCES.md

### DIFF
--- a/docs/DIFFERENCES.md
+++ b/docs/DIFFERENCES.md
@@ -47,16 +47,17 @@ Bellow follows a list of features comparing the official plugin to Cardinal.
 Additionally, Cardinal contains the following built-in modules not present in the official plugin or standalone:
 
  * Aria Salvatrice modules (except Arcane related modules, due to their online requirement)
+ * Arable Instruments and Parable Instruments (never updated to v2)
  * Mog (never updated to v2)
- * mscHack (never updated to v2)
- * rackwindows
- * AIDA-X
- * Audio File
- * Audio to CV Pitch converter
- * Carla Plugin Host
- * Ildaeil Host
- * glBars (OpenGL bars visualization, as seen in XMMS and XBMC/Kodi)
- * Text Editor (resizable and with syntax highlight)
- * Host Parameters (24 host-exposed parameters as CV sources)
- * Host Time (play, reset, bar, beat, tick, bar-phase and beat-phase CV sources)
- * Host CV (for the Raw-CV plugin variant, allows direct CV access to/from the DAW)
+ * Rackwindows (never updated to v2)
+ * The DISTRHO collection, including:
+   * AIDA-X
+   * Audio File
+   * Audio to CV Pitch converter
+   * Carla Plugin Host
+   * Ildaeil Host
+   * glBars (OpenGL bars visualization, as seen in XMMS and XBMC/Kodi)
+   * Text Editor (resizable and with syntax highlight)
+   * Host Parameters (24 host-exposed parameters as CV sources)
+   * Host Time (play, reset, bar, beat, tick, bar-phase and beat-phase CV sources)
+   * Host CV (for the Raw-CV plugin variant, allows direct CV access to/from the DAW)


### PR DESCRIPTION
In the section "Additionally, Cardinal contains the following built-in modules not present in the official plugin or standalone:"
- Removed mscHack (it was ported to v2)
- Added Arable Instruments and Parable Instruments
- Made it clear which modules were in the DISTRHO collection
- Minor grammar fixes