### PR TITLE
Sapphire v 2.5.3

### DIFF
--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -3119,6 +3119,7 @@ static void initStatic__Sapphire()
         p->addModel(modelSapphirePop);
         p->addModel(modelSapphireRotini);
         p->addModel(modelSapphireSam);
+        p->addModel(modelSapphireSauce);
         p->addModel(modelSapphireTin);
         p->addModel(modelSapphireTout);
         p->addModel(modelSapphireTricorder);


### PR DESCRIPTION
Updates Cardinal two versions from 2.5.1 to 2.5.3.

Includes the changes from 2.5.2, most notably the new polyphonic filter module Sauce.

Fixes in Pop for exact timing when CHAOS=0.

Make it easy to provide V/OCT input to Pop, Gravy, and Sauce. In all 3, the SPEED/FREQ attenuverter can now be set to 100% so that the CV input is interpreted on a volt-per-octave scale.