### PR TITLE
Sapphire v2.5.4: added Lark, a new chaotic oscillator module.

### DIFF
--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -3137,6 +3137,7 @@ static void initStatic__Sapphire()
         p->addModel(modelSapphireGlee);
         p->addModel(modelSapphireGravy);
         p->addModel(modelSapphireHiss);
+        p->addModel(modelSapphireLark);
         p->addModel(modelSapphireMoots);
         p->addModel(modelSapphireNucleus);
         p->addModel(modelSapphirePivot);


### PR DESCRIPTION
Added a new chaotic oscillator module [Lark](https://github.com/cosinekitty/sapphire/blob/main/Lark.md) that joins [Frolic](https://github.com/cosinekitty/sapphire/blob/main/Frolic.md) and [Glee](https://github.com/cosinekitty/sapphire/blob/main/Glee.md) as a way to generate interesting and unpredictable control voltages.