### PR TITLE
Add Nocturnal Encoder Modules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -260,4 +260,6 @@
 [submodule "plugins/admiral"]
 	path = plugins/admiral
 	url = https://github.com/wapiflapi/admiral.git
-
+[submodule "plugins/NocturnalEncoder"]
+	path = plugins/NocturnalEncoder
+	url = https://github.com/djpeterso23662/NocturnalEncoder.git

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -946,6 +946,11 @@ PLUGIN_FILES += $(filter-out MUS-X/src/plugin.cpp,$(wildcard MUS-X/src/*.cpp))
 PLUGIN_FILES += $(filter-out myth-modules/src/plugin.cpp,$(wildcard myth-modules/src/*.cpp))
 
 # --------------------------------------------------------------
+# Nocturnal Encoder
+
+PLUGIN_FILES += $(filter-out NocturnalEncoder/src/plugin.cpp,$(wildcard NocturnalEncoder/src/*.cpp))
+
+# --------------------------------------------------------------
 # Nonlinear Circuits
 
 PLUGIN_FILES += $(filter-out nonlinearcircuits/src/NLC.cpp,$(wildcard nonlinearcircuits/src/*.cpp))
@@ -2652,6 +2657,13 @@ $(BUILD_DIR)/myth-modules/%.cpp.o: myth-modules/%.cpp
 	$(SILENT)$(CXX) $< $(BUILD_CXX_FLAGS) -c -o $@ \
 		$(foreach m,$(MYTH_MODULES_CUSTOM),$(call custom_module_names,$(m),myth_modules)) \
 		-DpluginInstance=pluginInstance__myth_modules
+
+$(BUILD_DIR)/NocturnalEncoder/src/%.cpp.o: NocturnalEncoder/src/%.cpp
+	-@mkdir -p "$(shell dirname $(BUILD_DIR)/$<)"
+	@echo "Compiling $<"
+	$(SILENT)$(CXX) $< $(BUILD_CXX_FLAGS) -c -o $@ \
+		$(foreach m,$(CF_CUSTOM),$(call custom_module_names,$(m),NocturnalEncoder)) \
+		-DpluginInstance=pluginInstance__NocturnalEncoder
 
 $(BUILD_DIR)/nonlinearcircuits/%.cpp.o: nonlinearcircuits/%.cpp
 	-@mkdir -p "$(shell dirname $(BUILD_DIR)/$<)"

--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -774,6 +774,9 @@ extern Model* modelBlankPanel;
 // myth-modules
 #include "myth-modules/src/plugin.hpp"
 
+// Nocturnal Encoder
+#include "NocturnalEncoder/src/plugin.hpp"
+
 // Nonlinear Circuits
 #include "nonlinearcircuits/src/NLC.hpp"
 
@@ -970,6 +973,7 @@ extern Plugin* pluginInstance__mscHack;
 Plugin* pluginInstance__MSM;
 Plugin* pluginInstance__MUS_X;
 Plugin* pluginInstance__myth_modules;
+Plugin* pluginInstance__NocturnalEncoder;
 Plugin* pluginInstance__nonlinearcircuits;
 Plugin* pluginInstance__Orbits;
 Plugin* pluginInstance__ParableInstruments;
@@ -2919,6 +2923,18 @@ static void initStatic__myth_modules()
     }
 }
 
+static void initStatic__NocturnalEncoder()
+{
+    Plugin* const p = new Plugin;
+    pluginInstance__NocturnalEncoder = p;
+
+    const StaticPluginLoader spl(p, "NocturnalEncoder");
+    if (spl.ok())
+    {
+        p->addModel(modelAMDecoder);
+        p->addModel(modelAMEncoder);
+    }
+}
 static void initStatic__nonlinearcircuits()
 {
     Plugin* const p = new Plugin;
@@ -3557,6 +3573,7 @@ void initStaticPlugins()
     initStatic__MSM();
     initStatic__MUS_X();
     initStatic__myth_modules();
+    initStatic__NocturnalEncoder();
     initStatic__nonlinearcircuits();
     initStatic__Orbits();
     initStatic__ParableInstruments();


### PR DESCRIPTION
Adds the Nocturnal Encoder Modules. These modules allow Eurorack Synthesizers and Cardinal to interact with each other using either an AC-coupled or DC-coupled audio interface. (The current modules in Cardinal that do similar functions works only on DC-coupled interfaces, not AC-coupled ones.)

See also:
https://github.com/djpeterso23662/NocturnalEncoder?tab=readme-ov-file#compatibility