### PR TITLE
Sapphire v 2.5.5: new module Chaops.

### DIFF
--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -3150,6 +3150,7 @@ static void initStatic__Sapphire()
     const StaticPluginLoader spl(p, "Sapphire");
     if (spl.ok())
     {
+        p->addModel(modelSapphireChaops);
         p->addModel(modelSapphireElastika);
         p->addModel(modelSapphireFrolic);
         p->addModel(modelSapphireGalaxy);


### PR DESCRIPTION
* Added Chaops, a left-expander for chaos modules Frolic, Glee, and Lark that adds new functionality to them.
* Improved CPU efficiency of Frolic, Glee, Lark by 30x in Turbo Mode. No longer need a CPU usage warning.
* Display chaos mode on top of CHOAS knob in Glee and Lark.
* Display "T" on top of SPEED knob when Turbo Mode is enabled.