### PR TITLE
plugins/Makefile: use files to avoid hitting ARG_MAX during build

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -1438,6 +1438,7 @@ endif
 
 clean:
 	rm -f *.a
+	rm -f plugin_objs_list.txt mini_plugin_objs_list.txt
 	rm -rf $(BUILD_DIR)
 	rm -rf surgext/build
 
@@ -2060,12 +2061,18 @@ custom_per_file_names = -D${1}=${2}_${1}
 plugins$(TARGET_SUFFIX).a: $(PLUGIN_OBJS)
 	@echo "Creating $@"
 	$(SILENT)rm -f $@
-	$(SILENT)$(AR) crs $@ $^
+	# Write object file list to a response file and use it in the `ar` command
+	# to avoid hitting stack limits when using large number of modules
+	$(SILENT)$(file > plugin_objs_list.txt,$(PLUGIN_OBJS))
+	$(SILENT)$(AR) crs $@ @plugin_objs_list.txt
+	$(SILENT)rm -f plugin_objs_list.txt
 
 plugins-mini$(TARGET_SUFFIX).a: $(MINIPLUGIN_OBJS)
 	@echo "Creating $@"
 	$(SILENT)rm -f $@
-	$(SILENT)$(AR) crs $@ $^
+	$(SILENT)$(file > mini_plugin_objs_list.txt,$(MINIPLUGIN_OBJS))
+	$(SILENT)$(AR) crs $@ @mini_plugin_objs_list.txt
+	$(SILENT)rm -f mini_plugin_objs_list.txt
 
 $(BUILD_DIR)/%.bin.c: % ../deps/res2c.py
 	-@mkdir -p "$(shell dirname $(BUILD_DIR)/$<)"


### PR DESCRIPTION
When adding more modules to the build, ar will be passed far more .o files as arguments on the command line than the limits specified by most host kernels by default, which will cause the build to fail with `/bin/bash: Argument list too long`

Using xargs can show you what these limits are on POSIX systems, e.g:

```
$ xargs --show-limits
Your environment variables take up 6774 bytes
POSIX upper limit on argument length (this system): 2088330
POSIX smallest allowable upper limit on argument length (all systems): 4096
Maximum length of command we could actually use: 2081556
Size of command buffer we are actually using: 131072
Maximum parallelism (--max-procs must be no greater): 2147483647
```