### PR TITLE
Support triggering bar phase/clock every 4/8 bars

### DIFF
--- a/plugins/Cardinal/src/HostTime.cpp
+++ b/plugins/Cardinal/src/HostTime.cpp
@@ -157,10 +157,10 @@ struct HostTime : TerminalModule {
                               ? tick / pcontext->ticksPerBeat
                               : 0.0f;
         const float barPhase = playingWithBBT && pcontext->beatsPerBar > 0
-                              ? ((timeInfo.bar - 1) % barDivision) / (float) barDivision
-                                     + ((tick / pcontext->ticksPerBeat) / pcontext->beatsPerBar)
+                              ? ((float)((timeInfo.bar - 1) % barDivision) + (timeInfo.beat - 1) + beatPhase)
+                              / (pcontext->beatsPerBar * barDivision)
                               : 0.0f;
-
+        
         lights[kHostTimeRolling].setBrightness(playing ? 1.0f : 0.0f);
         lights[kHostTimeReset].setBrightnessSmooth(hasReset ? 1.0f : 0.0f, args.sampleTime * 0.5f);
         lights[kHostTimeBar].setBrightnessSmooth(hasBar ? 1.0f : 0.0f, args.sampleTime * 0.5f);


### PR DESCRIPTION
Support triggering bar phase/clock every 4 or 8 bars in the hosttime module by adding options to the right-click context menu.

(unforunately I don't have a Linux machine to build/test this)