### PR TITLE
Sapphire v2.5.9 - new module Echo

### DIFF
--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -3213,6 +3213,9 @@ static void initStatic__Sapphire()
     if (spl.ok())
     {
         p->addModel(modelSapphireChaops);
+        p->addModel(modelSapphireEcho);
+        p->addModel(modelSapphireEchoOut);
+        p->addModel(modelSapphireEchoTap);
         p->addModel(modelSapphireElastika);
         p->addModel(modelSapphireEnv);
         p->addModel(modelSapphireFrolic);


### PR DESCRIPTION
- Added a new multitap delay module: [Echo](https://github.com/cosinekitty/sapphire/blob/main/doc/Echo.md). 
- Added *neon mode* menu options to make the Sapphire panel glow. This effect is most visible when the room brightness is dim.
- Chaops did not reset the FREEZE button on initialize. This has been fixed.
- Fixed minor polyphony bug in Env: the number of channels in the GAIN control's CV input did not affect the number of output channels. This has been fixed.
- Fixed typos in help text for Gravy and Sauce.