### PR TITLE
Sapphire v 2.6.001

### DIFF
--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -3234,6 +3234,7 @@ static void initStatic__Sapphire()
         p->addModel(modelSapphireTout);
         p->addModel(modelSapphireTricorder);
         p->addModel(modelSapphireTubeUnit);
+        p->addModel(modelSapphireZoo);
     }
 }
 


### PR DESCRIPTION
Changes since Sapphire v 2.6.000:

- Added new module [Sapphire Zoo](https://github.com/cosinekitty/sapphire/blob/main/doc/Zoo.md), a programmable chaotic oscillator.
- "Insert Tricorder on right" is a new menu option present in all Sapphire modules that work with Tricorder.
- All [Sapphire chaos modules](https://github.com/cosinekitty/sapphire/blob/main/doc/SapphireChaosModules.md) now include "Insert Chaops on left" menu option.