### PR TITLE
Remove AS Blank Panel Special.

### DIFF
--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -405,7 +405,7 @@ ARIA_CUSTOM = Blank
 # --------------------------------------------------------------
 # AS
 
-PLUGIN_FILES += $(filter-out AS/src/AS.cpp,$(wildcard AS/src/*.cpp))
+PLUGIN_FILES += $(filter-out AS/src/AS.cpp AS/src/BlankPanelSpecial.cpp,$(wildcard AS/src/*.cpp))
 PLUGIN_FILES += AS/freeverb/revmodel.cpp
 
 # modules/types which are present in other plugins

--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -1499,7 +1499,9 @@ static void initStatic__AS()
         p->addModel(modelBlankPanel4);
         p->addModel(modelBlankPanel6);
         p->addModel(modelBlankPanel8);
-        p->addModel(modelBlankPanelSpecial);
+
+        //Copyright Violation
+        spl.removeModule("BlankPanelSpecial");
 #undef modelADSR
 #undef modelVCA
 #undef modelWaveShaper


### PR DESCRIPTION
Removes the AS Blank Panel Special from Cardinal.

This module should be removed from the project because it contains a copyright violation. You can see this yourself if you right click the module, and then select "Panel B".