### PR TITLE
Add the `Tuner` tag to AudioToCVPitch.

### DIFF
--- a/plugins/Cardinal/plugin.json
+++ b/plugins/Cardinal/plugin.json
@@ -171,6 +171,7 @@
       "description": "Converts a monophonic audio signal to CV pitch",
       "manualUrl": "https://github.com/DISTRHO/Cardinal/blob/main/docs/CARDINAL-MODULES.md#audio-to-cv-pitch",
       "tags": [
+        "Tuner",
         "Utility"
       ]
     },


### PR DESCRIPTION
_Audio To CV Pitch_ can:
- take in audio and output a voltage (similar to CV funk's _Tuner_), and
- can also transpose the pitch by several octaves (similar to 21kHz's _D∞_). 

Because of this, _Audio To CV Pitch_ could be given the `Tuner` tag.