### PR TITLE
Add TMT (T's Musical Tools) plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -266,3 +266,6 @@
 [submodule "plugins/Venom"]
 	path = plugins/Venom
 	url = https://github.com/DaveBenham/VenomModules
+[submodule "plugins/TMT"]
+	path = plugins/TMT
+	url = https://github.com/Jadael/TMT.git

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -1176,6 +1176,12 @@ PLUGIN_FILES += $(filter-out unless_modules/src/unless.cpp,$(wildcard unless_mod
 # modules/types which are present in other plugins
 UNLESS_MODULES_CUSTOM = Selection sign
 
+
+# --------------------------------------------------------------
+# TMT
+
+PLUGIN_FILES += $(filter-out TMT/src/plugin.cpp,$(wildcard TMT/src/*.cpp))
+
 # --------------------------------------------------------------
 # ValleyAudio
 
@@ -2807,6 +2813,11 @@ $(BUILD_DIR)/unless_modules/%.cpp.o: unless_modules/%.cpp
 	$(SILENT)$(CXX) $< $(BUILD_CXX_FLAGS) -c -o $@ \
 		$(foreach m,$(UNLESS_MODULES_CUSTOM),$(call custom_module_names,$(m),unless_modules)) \
 		-DpluginInstance=pluginInstance__unless_modules
+$(BUILD_DIR)/TMT/%.cpp.o: TMT/%.cpp
+	-@mkdir -p "$(shell dirname $(BUILD_DIR)/$<)"
+	@echo "Compiling $<"
+	$(SILENT)$(CXX) $< $(BUILD_CXX_FLAGS) -c -o $@ \
+		-DpluginInstance=pluginInstance__TMT
 
 $(BUILD_DIR)/ValleyAudio/%.cpp.o: ValleyAudio/%.cpp
 	-@mkdir -p "$(shell dirname $(BUILD_DIR)/$<)"


### PR DESCRIPTION
Adds TMT v2.2.0 as a git submodule to Cardinal.

TMT is a collection of esoteric VCV Rack modules focused on manipulating RNG and polyphonic signals, including:
- Shuffle: Randomly re-order polyphonic channels
- Calendar: LFO-like CVs synced to system time
- Seed: Generate 16 random voltages from a seed
- Ouroboros: Step through polyphonic channels as sequence
- Append: Combine multiple polyphonic cables
- Sight: Non-linear time scale scope
- Spellbook: Plain text RhythML sequencer
- Page: Spellbook expander for columns 17-32
- Stats: Statistical functions on polyphonic signals
- Sort: Sort and select channels using CV control
- Spine: Common voltage offsets and transformations
- Blankt: Resizable blank panel

License: AGPLv3
Repository: https://github.com/Jadael/TMT