### PR TITLE
FIX: off-by-one error when identifying patch/Rack version by reading the magic sequence of a zstd-compressed patch

### DIFF
--- a/src/CardinalPlugin.cpp
+++ b/src/CardinalPlugin.cpp
@@ -1104,7 +1104,7 @@ protected:
         rack::system::removeRecursively(fAutosavePath);
         rack::system::createDirectories(fAutosavePath);
 
-        static constexpr const uint8_t zstdMagic[] = { 0x28, 0xb5, 0x2f, 0xfd };
+        static constexpr const uint8_t zstdMagic[4] = { 0x28, 0xb5, 0x2f, 0xfd };
 
         if (std::memcmp(data.data(), zstdMagic, sizeof(zstdMagic)) != 0)
         {


### PR DESCRIPTION
Cardinal stopped loading my patches and instead was showing cleared (default template) versions. I was expecting that it was caused by the fact that I have updated Cardinal recently and somehow Ardour was complaining about new version of my vst3 plugins. It appeared that Cardinal was incorrectly identifying Rack v2 type of patches with the zstd magic sequence.