### PR TITLE
Support user-local resource path on macOS

### DIFF
--- a/src/CardinalCommon.cpp
+++ b/src/CardinalCommon.cpp
@@ -619,7 +619,16 @@ Initializer::Initializer(const CardinalBasePlugin* const plugin, const CardinalB
                #if defined(DISTRHO_OS_WASM)
                 asset::systemDir = "/resources";
                #elif defined(ARCH_MAC)
+                // Try system path first, fall back to user-local path for
+                // per-user installs from package managers (e.g. plug.audio)
                 asset::systemDir = "/Library/Application Support/Cardinal";
+                if (!system::exists(asset::systemDir))
+                {
+                    const std::string userDir = system::join(getSpecialDir(kSpecialDirHome),
+                        "Library" DISTRHO_OS_SEP_STR "Application Support" DISTRHO_OS_SEP_STR "Cardinal");
+                    if (system::exists(userDir))
+                        asset::systemDir = userDir;
+                }
                #elif defined(ARCH_WIN)
                 asset::systemDir = system::join(getSpecialPath(kSpecialPathCommonProgramFiles), "Cardinal");
                #else


### PR DESCRIPTION
## Summary

Adds a fallback to `~/Library/Application Support/Cardinal` when the system path `/Library/Application Support/Cardinal` doesn't exist on macOS.

## Why

Package managers like [plug](https://plug.audio) install plugins per-user (to `~/Library/Audio/Plug-Ins/`) to avoid requiring `sudo`. Resources also get installed per-user to `~/Library/Application Support/Cardinal/`. Currently Cardinal only checks the system path and fails with "System directory does not exist".

## Change

In `src/CardinalCommon.cpp`, after setting `asset::systemDir` to the system path, check if it exists. If not, check the user-local equivalent. If that exists, use it instead.

```cpp
asset::systemDir = "/Library/Application Support/Cardinal";
if (!system::exists(asset::systemDir))
{
    const std::string userDir = system::join(getSpecialDir(kSpecialDirHome),
        "Library" DISTRHO_OS_SEP_STR "Application Support" DISTRHO_OS_SEP_STR "Cardinal");
    if (system::exists(userDir))
        asset::systemDir = userDir;
}
```

## Backwards compatible

- System-level installs (via .pkg) continue to work as before
- Only falls back to user path when system path doesn't exist
- No change on Linux or Windows

Related: #915