### PR TITLE
Fix barPhase output and add Bars/2 division option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   CACHE_VERSION: 15

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 
 env:
   CACHE_VERSION: 15

--- a/plugins/Cardinal/src/HostTime.cpp
+++ b/plugins/Cardinal/src/HostTime.cpp
@@ -43,6 +43,7 @@ struct HostTime : TerminalModule {
 
     enum BarDivisions {
         Bars1 = 1,
+        Bars2 = 2,
         Bars4 = 4,
         Bars8 = 8
     };
@@ -158,9 +159,11 @@ struct HostTime : TerminalModule {
                               ? tick / pcontext->ticksPerBeat
                               : 0.0f;
         const float barPhase = playingWithBBT && pcontext->beatsPerBar > 0
-                              ? ((float)((timeInfo.bar - 1) % barDivision) + (timeInfo.beat - 1) + beatPhase)
-                              / (pcontext->beatsPerBar * barDivision)
-                              : 0.0f;
+                                ? fmod(
+                                    (timeInfo.bar - 1) + (timeInfo.beat - 1) / (float)pcontext->beatsPerBar + beatPhase / (float)pcontext->beatsPerBar,
+                                    (float)barDivision
+                                  ) / (float)barDivision
+                                : 0.0f;
 
         lights[kHostTimeRolling].setBrightness(playing ? 1.0f : 0.0f);
         lights[kHostTimeReset].setBrightnessSmooth(hasReset ? 1.0f : 0.0f, args.sampleTime * 0.5f);
@@ -192,7 +195,7 @@ struct HostTime : TerminalModule {
     void dataFromJson(json_t* rootJ) override {
         if (json_t* bdJ = json_object_get(rootJ, "barDivision")) {
             int value = json_integer_value(bdJ);
-            if (value == Bars1 || value == Bars4 || value == Bars8)
+            if (value == Bars1 || value == Bars2 || value == Bars4 || value == Bars8)
                 barDivision = static_cast<BarDivisions>(value);
         }
     }
@@ -327,6 +330,7 @@ struct HostTimeWidget : ModuleWidgetWith8HP {
         menu->addChild(new MenuSeparator);
         menu->addChild(construct<MenuLabel>(&MenuLabel::text, "Bar Division"));
         menu->addChild(construct<BarDivisionItem>(&BarDivisionItem::text, "Bars/1", &BarDivisionItem::module, module, &BarDivisionItem::value, HostTime::Bars1));
+        menu->addChild(construct<BarDivisionItem>(&BarDivisionItem::text, "Bars/2", &BarDivisionItem::module, module, &BarDivisionItem::value, HostTime::Bars2));
         menu->addChild(construct<BarDivisionItem>(&BarDivisionItem::text, "Bars/4", &BarDivisionItem::module, module, &BarDivisionItem::value, HostTime::Bars4));
         menu->addChild(construct<BarDivisionItem>(&BarDivisionItem::text, "Bars/8", &BarDivisionItem::module, module, &BarDivisionItem::value, HostTime::Bars8));
     }

--- a/plugins/Cardinal/src/HostTime.cpp
+++ b/plugins/Cardinal/src/HostTime.cpp
@@ -160,7 +160,7 @@ struct HostTime : TerminalModule {
                               : 0.0f;
         const float barPhase = playingWithBBT && pcontext->beatsPerBar > 0
                                 ? fmod(
-                                    (timeInfo.bar - 1) + (timeInfo.beat - 1) / (float)pcontext->beatsPerBar + beatPhase / (float)pcontext->beatsPerBar,
+                                    (timeInfo.bar - 1) + ((timeInfo.beat - 1) + beatPhase) / (float)pcontext->beatsPerBar,
                                     (float)barDivision
                                   ) / (float)barDivision
                                 : 0.0f;


### PR DESCRIPTION
The previous barPhase formula was incorrect for Bars/4 and Bars/8 modes. Instead of sweeping smoothly from 0 to 10V across the full bar division, it would produce an inconsistent sawtooth that reset at different voltages each bar cycle.

The fix normalizes the beat and sub-beat positions into a fractional bar count before applying fmod, producing a correct 0 10V phasor across the selected number of bars.

Also adds a Bars/2 division option to complement the existing Bars/1, Bars/4 and Bars/8 options.

Fixes #919 