### PR TITLE
Sapphire v2.6.004 - Introducing Empath

### DIFF
--- a/plugins/plugins.cpp
+++ b/plugins/plugins.cpp
@@ -3249,6 +3249,9 @@ static void initStatic__Sapphire()
         p->addModel(modelSapphireEchoOut);
         p->addModel(modelSapphireEchoTap);
         p->addModel(modelSapphireElastika);
+        p->addModel(modelSapphireEmpathInput);
+        p->addModel(modelSapphireEmpathFilter);
+        p->addModel(modelSapphireEmpathOutput);
         p->addModel(modelSapphireEnv);
         p->addModel(modelSapphireFrolic);
         p->addModel(modelSapphireGalaxy);


### PR DESCRIPTION
In collaboration with Omri Cohen, this Sapphire release introduces a new module: Empath, an expander chain that allows building an array of parallel complex filters.

Version 2.6.004 also includes numerous improvements and fixes to other modules, as detailed in the [change log](https://github.com/cosinekitty/sapphire/blob/main/CHANGELOG.md).

NOTE: The previous PR needed a code update to work in VCV Rack. I was not able to update the existing PR for boring reasons. I closed the old PR and re-created the correct one. This brings Cardinal in sync with Sapphire v2.6.004 source.